### PR TITLE
Prevent git clone / wget issues during re-run of install.sh

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -109,11 +109,11 @@ case $yn in
     [Yy]* )
         echo -----------------------
         echo Downloading PDP-10 ITS disk images
-        wget -P /opt/pidp10/systems/its https://pidp.net/pidp10-sw/its-system.zip
+        wget -O /opt/pidp10/systems/its/its-system.zip https://pidp.net/pidp10-sw/its-system.zip
 	unzip -d /opt/pidp10/systems/its /opt/pidp10/systems/its/its-system.zip
         echo -----------------------
         echo Downloading PDP-10 TOPS-10 disk images
-        wget -P /opt/pidp10/systems/tops10-603 https://pidp.net/pidp10-sw/tops603ka.zip
+        wget -O /opt/pidp10/systems/tops10-603/tops603ka.zip https://pidp.net/pidp10-sw/tops603ka.zip
         unzip -d /opt/pidp10/systems/tops10-603 /opt/pidp10/systems/tops10-603/tops603ka.zip
         echo -----------------------
         ;;

--- a/install/install.sh
+++ b/install/install.sh
@@ -93,8 +93,8 @@ case $yn in
         sudo apt-get install -y screen
 	# Install Tilix, used for pdp view
 	sudo apt -y install tilix
-    sudo apt -y install dconf-editor dconf-cli
-    dconf load /com/gexperts/Tilix/ </opt/pidp10/install/pidp10tilix.conf
+	sudo apt -y install dconf-editor dconf-cli
+	dconf load /com/gexperts/Tilix/ </opt/pidp10/install/pidp10tilix.conf
         ;;
     [Nn]* ) ;;
         * ) echo "Please answer yes or no.";;
@@ -227,13 +227,13 @@ case $yn in
 	sudo apt install -y libvdeplug2
 	# addl from Lars' its/build/dependencies script
 	sudo apt-get install -y libegl1-mesa-dev libgles2-mesa-dev
-# for networking support in simh:
+	# for networking support in simh:
         sudo apt-get install -y libpcap-dev
         sudo apt-get install -y libvdeplug-dev
         #Install readline, used for command-line editing in simh
         sudo apt-get install -y libreadline-dev
         #the above might be superceded by the one below now - at least for the Pi
-#CHECK!
+	#CHECK!
         sudo apt install -y libedit-dev
 	# for sty:
 	# this one I'm not sure of --

--- a/install/install.sh
+++ b/install/install.sh
@@ -173,6 +173,8 @@ read -p "Download PDP-10 emulator source code? " yn
 case $yn in
     [Yy]* )
         cd /opt/pidp10/src
+        # clean up the git source directory if it already exists
+        if [ -d /opt/pidp10/src/pidp10 ]; then rm -rf /opt/pidp10/src/pidp10; fi
         git clone https://github.com/rcornwell/pidp10
         # 20240312 delete duplicate files in Richard's pidp10 fork, we want the emulator
 	# and not a duplicate of all the other pidp10 files, that we already have

--- a/install/install.sh
+++ b/install/install.sh
@@ -24,14 +24,14 @@ echo This script is minimally invasive to your Linux. All it does outside
 echo its own directory is, if you allow, \(a\) make 2 links in \/usr\/bin and
 echo \(b\) add \'pdpcontrol\' to your \~\/.profile
 echo
-echo The script can be re-run later on to add the source code and its 
+echo The script can be re-run later on to add the source code and its
 echo dependencies. Re-running the script and answering \'n\' to questions
 echo will leave those things unchanged. So it will *not* undo anything
 echo that is already installed.
 echo
 echo Too Long, Didn\'t Read?
 echo Just say Yes to everything except say No to \'install source code\'
-echo and to \'install source code dependencies\'. 
+echo and to \'install source code dependencies\'.
 echo
 echo
 echo NEW SIMULATOR VERSION FROM RICHARD CORNWELL
@@ -43,7 +43,7 @@ read -p "Set required access privileges to pidp10 simulator? " yn
 case $yn in
     [Yy]* )
 	    # make sure that the directory does not have root ownership
-	    # (in case the user did a simple git clone instead of 
+	    # (in case the user did a simple git clone instead of
 	    #  sudo -u pi git clone...)
 	    myusername=$(whoami)
 	    mygroup=$(id -g -n)
@@ -64,7 +64,7 @@ esac
 # ---------------------------
 read -p "Copy control script links (pdpcontrol, pdp) to /usr/local/bin? " yn
 case $yn in
-    [Yy]* ) 
+    [Yy]* )
 	    sudo ln -i -s /opt/pidp10/bin/pdp.sh /usr/local/bin/pdp
 	    sudo ln -i -s /opt/pidp10/bin/pdpcontrol.sh /usr/local/bin/pdpcontrol
         ;;
@@ -75,7 +75,7 @@ esac
 
 read -p "Install required dependencies for running the PiDP-10? " yn
 case $yn in
-    [Yy]* ) 
+    [Yy]* )
         # update first...
         sudo apt-get update
         # for simh:
@@ -87,7 +87,7 @@ case $yn in
 	#the Pi does not come with telnet installed, so --
         sudo apt-get install -y telnet
         sudo apt-get install -y telnetd
-	# for pdpcontrol: 
+	# for pdpcontrol:
 	sudo apt-get -y install expect
         # Install screen
         sudo apt-get install -y screen
@@ -106,7 +106,7 @@ esac
 # ---------------------------
 read -p "Download and install required disk images? " yn
 case $yn in
-    [Yy]* ) 
+    [Yy]* )
         echo -----------------------
         echo Downloading PDP-10 ITS disk images
         wget -P /opt/pidp10/systems/its https://pidp.net/pidp10-sw/its-system.zip
@@ -128,13 +128,13 @@ esac
 
 read -p "Use currently installed PDP-10 simulator (yes makes sense)? " ynx
 case $ynx in
-	[Yy]* ) 
+	[Yy]* )
 		echo --> Leaving things untouched
 		;;
-	[Nn]* ) 
+	[Nn]* )
 		read -p "Install (p)revious or (c)urrent PDP-10 simulator, or (l)eave as-is? " yn
 		case $yn in
-			[Pp]* ) 
+			[Pp]* )
 				echo copying pidp10.panama to pidp10
 				cp /opt/pidp10/bin/pidp10.panama /opt/pidp10/bin/pidp10
 				# make sure pidp10 simulator has the right privileges
@@ -143,7 +143,7 @@ case $ynx in
 				# to run a RT thread:
 				sudo setcap cap_sys_nice+ep /opt/pidp10/bin/pidp10
 				;;
-			[Cc]* ) 
+			[Cc]* )
 				echo copying pdp10-ka to pidp10
 				cp /opt/pidp10/bin/pdp10-ka /opt/pidp10/bin/pidp10
 				# make sure pidp10 simulator has the right privileges
@@ -152,10 +152,10 @@ case $ynx in
 				# to run a RT thread:
 				sudo setcap cap_sys_nice+ep /opt/pidp10/bin/pidp10
 				;;
-			[Ll]* ) 
+			[Ll]* )
 				echo Leaving things untouched from how they were
 				;;
-			* ) 
+			* )
 				echo "Please answer p,c, or in case of doubt, l."
 				;;
 		esac
@@ -171,7 +171,7 @@ esac
 # ---------------------------
 read -p "Download PDP-10 emulator source code? " yn
 case $yn in
-    [Yy]* ) 
+    [Yy]* )
         cd /opt/pidp10/src
         git clone https://github.com/rcornwell/pidp10
         # 20240312 delete duplicate files in Richard's pidp10 fork, we want the emulator
@@ -199,7 +199,7 @@ esac
 # ---------------------------
 read -p "Download ITS project source code? " yn
 case $yn in
-    [Yy]* ) 
+    [Yy]* )
         cd /opt/pidp10/src
         git clone https://github.com/PDP-10/its.git
         # get all the submodules (vt05, tektronix, etc)
@@ -214,7 +214,7 @@ esac
 
 read -p "Install add'l dependencies for compiling the source code? " yn
 case $yn in
-    [Yy]* ) 
+    [Yy]* )
         # update first...
         sudo apt-get update
         # for its install process:
@@ -239,8 +239,8 @@ case $yn in
 	# this one I'm not sure of --
 	sudo apt install -y libx11-dev libxt-dev	//not xft, fixed
 	#
-	sudo apt-get install -y libsdl2-mixer-dev  
-	sudo apt-get install -y libsdl2-ttf-dev  
+	sudo apt-get install -y libsdl2-mixer-dev
+	sudo apt-get install -y libsdl2-ttf-dev
         ;;
     [Nn]* ) ;;
         * ) echo "Please answer yes or no.";;
@@ -252,7 +252,7 @@ esac
 # ---------------------------
 read -p "Let raspi-config enable i2c, VNC? " yn
 case $yn in
-    [Yy]* ) 
+    [Yy]* )
 	# enable I2C on the Pi
 	sudo raspi-config nonint do_i2c 0
 	# enable vnc
@@ -282,7 +282,7 @@ append_to_file() {
 
 read -p "Automatically start the PiDP-10 core when logging in? " yn
 case $yn in
-    [Yy]* ) 
+    [Yy]* )
 	echo testing for .profile or otherwise, .bash_profile
 	if [ -f "$HOME/.profile" ]; then
 		echo .profile found
@@ -305,7 +305,7 @@ esac
 # ---------------------------
 read -p "Install Teletype font? " yn
 case $yn in
-    [Yy]* ) 
+    [Yy]* )
         mkdir ~/.fonts
         cp /opt/pidp10/install/TELETYPE1945-1985.ttf ~/.fonts/
 	fc-cache -v -f
@@ -321,7 +321,7 @@ esac
 echo If you are not installing on a Pi, say No:
 read -p "Add a DEC flavour to the Pi's desktop? " yn
 case $yn in
-	[Yy]* ) 
+	[Yy]* )
 		# wall paper
 		pcmanfm --set-wallpaper /opt/pidp10/install/turist.png --wallpaper-mode=fit
 		# desktop files in Pi menu

--- a/install/install.sh
+++ b/install/install.sh
@@ -129,7 +129,7 @@ esac
 read -p "Use currently installed PDP-10 simulator (yes makes sense)? " ynx
 case $ynx in
 	[Yy]* )
-		echo --> Leaving things untouched
+		echo "--> Leaving things untouched"
 		;;
 	[Nn]* )
 		read -p "Install (p)revious or (c)urrent PDP-10 simulator, or (l)eave as-is? " yn

--- a/install/install.sh
+++ b/install/install.sh
@@ -83,11 +83,11 @@ case $yn in
 	#the Pi does not come with telnet installed, so --
         sudo apt-get install -y telnet telnetd
 	# for pdpcontrol:
-	sudo apt-get -y install expect
+	sudo apt-get install -y expect
         # Install screen
         sudo apt-get install -y screen
 	# Install Tilix, used for pdp view
-	sudo apt -y install tilix dconf-editor dconf-cli
+	sudo apt install -y tilix dconf-editor dconf-cli
 	dconf load /com/gexperts/Tilix/ </opt/pidp10/install/pidp10tilix.conf
         ;;
     [Nn]* ) ;;
@@ -214,9 +214,9 @@ case $yn in
         # update first...
         sudo apt-get update
         # for its install process:
-        sudo apt-get -y install autoconf
+        sudo apt-get install -y autoconf
         # for graphics options in simh:
-        sudo apt-get -y install libsdl2-dev libgtk-3-dev
+        sudo apt-get install -y libsdl2-dev libgtk-3-dev
         # for simh:
 	sudo apt install -y libpcre3-dev libvdeplug2
 	# addl from Lars' its/build/dependencies script

--- a/install/install.sh
+++ b/install/install.sh
@@ -79,21 +79,15 @@ case $yn in
         # update first...
         sudo apt-get update
         # for simh:
-	sudo apt install -y libpcre3
-        sudo apt install -y libsdl2-image-dev
-        sudo apt install -y libsdl2-net-dev
-	sudo apt install -y libvdeplug2
-	sudo apt install -y libpcap-dev
+	sudo apt install -y libpcre3 libsdl2-image-dev libsdl2-net-dev libvdeplug2 libpcap-dev
 	#the Pi does not come with telnet installed, so --
-        sudo apt-get install -y telnet
-        sudo apt-get install -y telnetd
+        sudo apt-get install -y telnet telnetd
 	# for pdpcontrol:
 	sudo apt-get -y install expect
         # Install screen
         sudo apt-get install -y screen
 	# Install Tilix, used for pdp view
-	sudo apt -y install tilix
-	sudo apt -y install dconf-editor dconf-cli
+	sudo apt -y install tilix dconf-editor dconf-cli
 	dconf load /com/gexperts/Tilix/ </opt/pidp10/install/pidp10tilix.conf
         ;;
     [Nn]* ) ;;
@@ -222,16 +216,13 @@ case $yn in
         # for its install process:
         sudo apt-get -y install autoconf
         # for graphics options in simh:
-        sudo apt-get -y install libsdl2-dev
-        sudo apt-get install -y libgtk-3-dev
+        sudo apt-get -y install libsdl2-dev libgtk-3-dev
         # for simh:
-	sudo apt install -y libpcre3-dev
-	sudo apt install -y libvdeplug2
+	sudo apt install -y libpcre3-dev libvdeplug2
 	# addl from Lars' its/build/dependencies script
 	sudo apt-get install -y libegl1-mesa-dev libgles2-mesa-dev
 	# for networking support in simh:
-        sudo apt-get install -y libpcap-dev
-        sudo apt-get install -y libvdeplug-dev
+        sudo apt-get install -y libpcap-dev libvdeplug-dev
         #Install readline, used for command-line editing in simh
         sudo apt-get install -y libreadline-dev
         #the above might be superceded by the one below now - at least for the Pi
@@ -241,8 +232,7 @@ case $yn in
 	# this one I'm not sure of --
 	sudo apt install -y libx11-dev libxt-dev	//not xft, fixed
 	#
-	sudo apt-get install -y libsdl2-mixer-dev
-	sudo apt-get install -y libsdl2-ttf-dev
+	sudo apt-get install -y libsdl2-mixer-dev libsdl2-ttf-dev
         ;;
     [Nn]* ) ;;
         * ) echo "Please answer yes or no.";;

--- a/install/install.sh
+++ b/install/install.sh
@@ -160,7 +160,7 @@ case $ynx in
 				;;
 		esac
 		;;
-	* ) 
+	* )
 		echo "Please answer yes or no."
 		;;
 esac
@@ -287,7 +287,6 @@ case $yn in
 	if [ -f "$HOME/.profile" ]; then
 		echo .profile found
 		append_to_file "$HOME/.profile"
-
 	elif [ -f "$HOME/.bash_profile" ]; then
 		echo .bash_profile found
 		append_to_file "$HOME/.bash_profile"
@@ -336,4 +335,3 @@ esac
 echo
 echo Done.
 echo
-


### PR DESCRIPTION
~~Addresses https://github.com/obsolescence/pidp10/issues/12 and~~ some comments from https://groups.google.com/g/pidp-10/c/csbzz40gSQA/m/fwibojMWAQAJ

Minor installer improvements:
* ~~Removes the destination folder for `git clone` of https://github.com/rcornwell/pidp10 if it already exists. Resolves an error that happens if you re-run the installer script.~~
* Changes the syntax for `wget` to prevent multiple copies of the file from accumulating if you re-run the installer script.
* Resolves a syntax error caused by `-->` in an unquoted string. This was an issue because it is interpreted by the shell as an output redirection.
* Combines multiple package installs which happen in a row. This should make the installation slightly faster & less chatty.

Cosmetic changes:
* standardizes apt syntax: `-y install` vs `install -y`
* cleans up whitespace, newlines, etc

Open Questions:
* Sometimes we are using `apt` and sometimes `apt-get` - not sure if this is intentional
* There are technically some undeclared dependencies in this script. If this is intended for RasPi OS & these are provided by default, perhaps it's not a problem. I only found this because my test environment is a minimal Ubuntu container.
  * `wget`
  * `unzip`
  * `setcap` (provided by `libcap2-bin` in Ubuntu)
* ~~The same issue with `git clone` may also happen with https://github.com/PDP-10/its.git~~