### PR TITLE
some of the cleanups are in src  not the root of the checkout

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -181,10 +181,10 @@ case $yn in
 	rm -r systems
 	rm -r install
 	rm -r bin
-	rm -r panama5
-	rm -r pidp10-test
-	rm -r scansw10
-	rm -r sty33
+	rm -r src/panama5
+	rm -r src/pidp10-test
+	rm -r src/scansw10
+	rm -r src/sty33
         #git submodule sync
         #git submodule update --init --recursive
         ;;


### PR DESCRIPTION
add src/ to the rm's for the panama5 pidp10-test scansw10 sty33 as that is where they are. though realistically we should just leave everything there as it will all be added back when doing a "git pull --rebase" Ideally we had a git repo with just the sources for the PiDP-10 without everything else.