### PR TITLE
Make timeout permanent

### DIFF
--- a/bin/cbridge.conf
+++ b/bin/cbridge.conf
@@ -10,8 +10,14 @@ ncp enabled yes
 ; Private (unrouted) hosts
 private hosts /opt/pidp10/bin/chaos-hosts
 
-; Link to ITS on pit
-link chudp localhost:44042 host 177002 myaddr 177001
+; Link to ITS on pit - use 127.0.0.1 rather than localhost, since we want
+; to avoid IPv6 here
+link chudp 127.0.0.1:44042 host 177002 myaddr 177001
 
-; Link to beast
-link chudp beast:44043 host 177003 myaddr 177001
+; Link to BEAST cbridge
+link chudp beast:44042 host 177003 myaddr 177001
+
+; I don't need this - the above link to beast cbridge is sufficient.  But I
+; probably would need it if beast also had simulators running that pit
+; needed to talk to.
+;route subnet 376 bridge 177003

--- a/bin/cbridge.conf
+++ b/bin/cbridge.conf
@@ -1,5 +1,17 @@
+; Our bridge address
 chaddr 177001
+
+; Our UDP port
 chudp 44041
+
+; Enable transport layer
 ncp enabled yes
+
+; Private (unrouted) hosts
 private hosts /opt/pidp10/bin/chaos-hosts
+
+; Link to ITS on pit
 link chudp localhost:44042 host 177002 myaddr 177001
+
+; Link to beast
+link chudp beast:44043 host 177003 myaddr 177001

--- a/bin/cbridge.conf
+++ b/bin/cbridge.conf
@@ -20,4 +20,4 @@ link chudp beast:44042 host 177003 myaddr 177001
 ; I don't need this - the above link to beast cbridge is sufficient.  But I
 ; probably would need it if beast also had simulators running that pit
 ; needed to talk to.
-;route subnet 376 bridge 177003
+route subnet 376 bridge 177003

--- a/bin/chaos-hosts
+++ b/bin/chaos-hosts
@@ -1,2 +1,3 @@
 177001	bridge gw
 177002	its db ka kl
+177003	beast

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,7 @@
+# its comes from https://github.com/PDP-10/its.git, but not as a submodule, so
+# we want to exclude it.
+its
+
+# pidp10 comes from https://github.com/rcornwell/pidp10, but not as a
+# submodule, so we want to exclude it.
+pidp10

--- a/src/compiling-pdp10-readme.txt
+++ b/src/compiling-pdp10-readme.txt
@@ -1,6 +1,6 @@
 As of 20240312:
 - run install.sh to clone Cornwell's PIDP-10 repository,
-- cd opt/pidp10/src/pidp10/src/pdp10
+- cd /opt/pidp10/src/pidp10/src/pdp10
 - make PIDP10=1
 - cp BIN/p* /opt/pidp10/bin
 

--- a/systems/.gitignore
+++ b/systems/.gitignore
@@ -1,0 +1,5 @@
+# The installer wgets tops20-panda.zip and then unpacks it.  No need to include
+# this stuff.
+boot.sav
+RH20.RP07.1
+tops20-panda.zip

--- a/systems/its/boot.pi
+++ b/systems/its/boot.pi
@@ -69,15 +69,21 @@ set imp mac=e2:6c:84:1d:34:a3
 #---------------------------
 # option 1: lowest-effort networking using simh NAT interface
 # KA10 ip address will be 10.0.2.15
-set imp dhcp
-set imp host=10.3.0.6
-at imp nat:tcp=2123:10.0.2.15:23,tcp=2121:10.0.2.15:21,tcp=2195:10.0.2.15:95
+#set imp dhcp
+#set imp host=10.3.0.6
+#at imp nat:tcp=2123:10.0.2.15:23,tcp=2121:10.0.2.15:21,tcp=2195:10.0.2.15:95
 #---------------------------
 #option 2: the default setup
 #set imp ip=192.168.2.101/24
 #set imp gw=172.31.1.100
 #set imp host=10.3.0.6
 #at imp tap:tap0
+#---------------------------
+#option 3: custom Falco setup
+set imp ip=192.168.0.7/24
+set imp gw=192.168.0.1
+set imp host=10.3.0.6
+at imp tap:tap0
 #---------------------------
 at ptr ./dskdmp.rim
 at dpa0 ./rp03.2

--- a/systems/its/boot.pi
+++ b/systems/its/boot.pi
@@ -112,10 +112,11 @@ set imx channel=76;unit3;axis1;negate
 set imx channel=74;unit3;axis3
 
 ; ------------
-; enable chaosnet
+; enable chaosnet - use 127.0.0.1 rather than localhost, since we prefer
+; not to use IPv6 here.
 set ch enabled
 set ch node=177002
-set ch peer=localhost:44041
+set ch peer=127.0.0.1:44041
 att ch 44042
 ; --------------
 ; just quit on SIGTERM

--- a/systems/its/boot.pidp
+++ b/systems/its/boot.pidp
@@ -111,10 +111,11 @@ set imx channel=76;unit3;axis1;negate
 set imx channel=74;unit3;axis3
 
 ; ------------
-; enable chaosnet
+; enable chaosnet - use 127.0.0.1 rather than localhost, since we prefer
+; not to use IPv6 here.
 set ch enabled
 set ch node=177002
-set ch peer=localhost:44041
+set ch peer=127.0.0.1:44041
 att ch 44042
 ; --------------
 ; just quit on SIGTERM

--- a/systems/its/boot.pidp
+++ b/systems/its/boot.pidp
@@ -69,15 +69,21 @@ set imp mac=e2:6c:84:1d:34:a3
 #---------------------------
 # option 1: lowest-effort networking using simh NAT interface
 # KA10 ip address will be 10.0.2.15
-set imp dhcp
-set imp host=10.3.0.6
-at imp nat:tcp=2123:10.0.2.15:23,tcp=2121:10.0.2.15:21,tcp=2195:10.0.2.15:95
+#set imp dhcp
+#set imp host=10.3.0.6
+#at imp nat:tcp=2123:10.0.2.15:23,tcp=2121:10.0.2.15:21,tcp=2195:10.0.2.15:95
 #---------------------------
 #option 2: the default setup
 #set imp ip=192.168.2.101/24
 #set imp gw=172.31.1.100
 #set imp host=10.3.0.6
 #at imp tap:tap0
+#---------------------------
+#option 3: custom Falco setup
+set imp ip=192.168.0.7/24
+set imp gw=192.168.0.1
+set imp host=10.3.0.6
+at imp tap:tap0
 #---------------------------
 at ptr ./dskdmp.rim
 at dpa0 ./rp03.2
@@ -135,16 +141,15 @@ set dpy ena
 dep readin 104
 
 ; ----------------------------------------------------------------
-; so the user has a PiDP-10 front panel and should press READ IN before
-; booting starts.
+; so the user has a PiDP-10 front panel and should press STOP then
+; READ IN to boot.
 ; This little blinky program is run until the moment that he does:
 d 1000 201000000777
 d 1001 241000000001
-d 1002 202000001007
-d 1003 700540001007
-d 1004 201100060650
+d 1002 700540000000
+d 1003 201100060650
+d 1004 242100000004
 d 1005 366100001005
 d 1006 324000001001
-d 1007 000000000000
 go 1000
 ;b ptr


### PR DESCRIPTION
The install script sets net.ipv4.tcp_fin_timeout to "1", but that will not survive a reboot.  We also have to put a file into /etc/sysctl.d/ to make the change permanent.